### PR TITLE
Added FixVariantCollisions to PhasedPanelEvaluation WDL.

### DIFF
--- a/wdl/evaluation/phased-panel/VcfdistAndOverlapMetricsEvaluation.wdl
+++ b/wdl/evaluation/phased-panel/VcfdistAndOverlapMetricsEvaluation.wdl
@@ -217,7 +217,7 @@ task CalculateOverlapMetrics {
             chrom_v = split_callset['variants/CHROM'][is_multi_V]
             pos_v = split_callset['variants/POS'][is_multi_V]
             samples_s = split_callset['samples']
-            
+
             # group split records by multiallelic site (indexed by m)
             m_splits = np.unique(pos_v, return_index=True)[1][1:]
             gt_mvsp = np.split(gt_vsp, m_splits)

--- a/wdl/methods/pangenie/PanGeniePanelCreation.wdl
+++ b/wdl/methods/pangenie/PanGeniePanelCreation.wdl
@@ -18,6 +18,7 @@ workflow PanGeniePanelCreation {
         File prepare_vcf_script
         File add_ids_script
         File merge_vcfs_script
+        Float frac_missing = 0.2
         String output_prefix
 
         String docker
@@ -31,6 +32,7 @@ workflow PanGeniePanelCreation {
             prepare_vcf_script = prepare_vcf_script,
             add_ids_script = add_ids_script,
             merge_vcfs_script = merge_vcfs_script,
+            frac_missing = frac_missing,
             output_prefix = output_prefix,
             docker = docker,
             monitoring_script = monitoring_script
@@ -53,7 +55,7 @@ task PanGeniePanelCreation {
         File prepare_vcf_script
         File add_ids_script
         File merge_vcfs_script
-        Float frac_missing = 0.2
+        Float frac_missing
 
         String docker
         File? monitoring_script


### PR DESCRIPTION
Note that we use `sed` to replace the missing alleles (correctly) emitted by FixVariantCollisions with ref alleles (which technically yield inconsistent haplotypes when represented as split biallelics, e.g. `1|2` -> `1|0` + `0|1`, see #24). This is what is expected by the PanGenie script, which otherwise also drops sites with missing alleles (along with site with inconsistent haplotypes). We should clean this up at some point, along with things like the use of the GATK Docker (all we really need is Java + bcftools for the FixVariantCollisions task as currently written).

Closes #27.